### PR TITLE
add operation - ADC

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -45,6 +45,13 @@ impl CPU {
 
         let operations: HashMap<u8, Operation> = HashMap::from([
             (0x69/*noice*/, Operation::new(ADC, Immediate, 2)),
+            (0x65, Operation::new(ADC, ZeroPage, 2)),
+            (0x75, Operation::new(ADC, ZeroPageX, 2)),
+            (0x6D, Operation::new(ADC, Absolute, 3)),
+            (0x7D, Operation::new(ADC, AbsoluteX, 3)),
+            (0x79, Operation::new(ADC, AbsoluteY, 3)),
+            (0x61, Operation::new(ADC, IndirectX, 2)),
+            (0x71, Operation::new(ADC, IndirectY, 2)),
 
             (0x00, Operation::new(BRK, Implied, 1)),
             

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -25,6 +25,7 @@ bitflags! {
     ///  | |   +----------- Break Command
     ///  | +--------------- Overflow Flag
     ///  +----------------- Negative Flag
+    #[derive(PartialEq, Eq, Clone, Copy)]
     pub struct Flags: u8 {
         const Init = 0b0011_0000;
         const Carry = 0b0000_0001;
@@ -150,14 +151,14 @@ impl CPU {
                 return addr.wrapping_add(self.register_y as u16);
             }
             IndirectX => {
-                let mut addr = self.memory.read(self.program_counter);
-                addr = addr.wrapping_add(self.register_x);
+                let zero_page_addr = self.memory.read(self.program_counter);
+                let addr = zero_page_addr.wrapping_add(self.register_x);
                 return self.memory.read_u16(addr as u16);
             }
             IndirectY => {
-                let mut addr = self.memory.read(self.program_counter);
-                addr = addr.wrapping_add(self.register_y);
-                return self.memory.read_u16(addr as u16);
+                let zero_page_addr = self.memory.read(self.program_counter);
+                let addr = self.memory.read_u16(zero_page_addr as u16);
+                return addr.wrapping_add(self.register_y as u16);
             }
             Implied => {
                 panic!("operation does not require target address");
@@ -201,11 +202,17 @@ impl CPU {
 
     fn adc(&mut self, mode: AddressingMode) {
         let addr = self.get_op_target_addr(mode);
-        let mem_value = self.memory.read(addr);
 
-        let wrapped_sum = self.register_a.wrapping_add(mem_value);
+        let mem_value = self.memory.read(addr);
+        let carry_in: u8 = if self.carry_flag() { 1 } else { 0 };
+
+        let wrapped_sum = self.register_a.wrapping_add(mem_value + carry_in);
+
+        let carry_out = wrapped_sum < self.register_a;
+        let overflow = ((self.register_a ^ wrapped_sum) & (mem_value ^ wrapped_sum) & 0x80) != 0;
         
-        self.set_carry_flag(wrapped_sum < self.register_a);
+        self.set_carry_flag(carry_out);
+        self.set_overflow_flag(overflow);
         self.set_register_a(wrapped_sum);
     }
 
@@ -253,10 +260,6 @@ impl CPU {
         self.set_negative_flag(self.register_y)
     }
 
-    pub fn zero_flag(&mut self) -> bool {
-        return self.status.contains(Flags::Zero);
-    }
-
     fn set_zero_flag(&mut self, value: u8) {
         if value == 0 {
             self.status.insert(Flags::Zero);
@@ -273,8 +276,8 @@ impl CPU {
         }
     }
 
-    pub fn negative_flag(&mut self) -> bool {
-        return self.status.contains(Flags::Negative);
+    fn carry_flag(&mut self) -> bool {
+        return self.status.contains(Flags::Carry);
     }
 
     fn set_carry_flag(&mut self, value: bool) {
@@ -282,6 +285,14 @@ impl CPU {
             self.status.insert(Flags::Carry);
         } else {
             self.status.remove(Flags::Carry);
+        }
+    }
+
+    fn set_overflow_flag(&mut self, value: bool) {
+        if value {
+            self.status.insert(Flags::Overflow);
+        } else {
+            self.status.remove(Flags::Overflow);
         }
     }
 }

--- a/tests/adc_tests.rs
+++ b/tests/adc_tests.rs
@@ -1,5 +1,8 @@
 use std::vec;
-use nes_emulator::cpu::CPU;
+use nes_emulator::cpu::{CPU, Flags};
+
+mod common;
+use common::{assert_no_flags, assert_flags};
 
 #[test]
 fn test_0x69_adc_immediate_adds_correctly() {
@@ -9,7 +12,19 @@ fn test_0x69_adc_immediate_adds_correctly() {
     cpu.load_and_run_without_reset(vec![0x69, 0x01, 0x00]);
 
     assert_eq!(cpu.register_a, 0x02);
-    assert_eq!(cpu.status.bits(), 0b0011_0000);
+    assert_no_flags(&cpu);
+}
+
+#[test]
+fn test_0x69_adc_immediate_carry_in() {
+    let mut cpu = CPU::new();
+    cpu.status.insert(Flags::Carry);
+    cpu.register_a = 0x01;
+
+    cpu.load_and_run_without_reset(vec![0x69, 0x01, 0x00]);
+
+    assert_eq!(cpu.register_a, 0x03);
+    assert_no_flags(&cpu);
 }
 
 #[test]
@@ -20,7 +35,7 @@ fn test_0x69_adc_immediate_zero_flag() {
     cpu.load_and_run_without_reset(vec![0x69, 0x00, 0x00]);
     
     assert_eq!(cpu.register_a, 0x00);
-    assert_eq!(cpu.status.bits(), 0b0011_0010);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
@@ -31,7 +46,7 @@ fn test_0x69_adc_immediate_negative_flag() {
     cpu.load_and_run_without_reset(vec![0x69, 0b1000_0001, 0x00]);
     
     assert_eq!(cpu.register_a, 0b1000_0001);
-    assert_eq!(cpu.status.bits(), 0b1011_0000);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }
 
 #[test]
@@ -42,29 +57,191 @@ fn test_0x69_adc_immediate_carry_flag() {
     cpu.load_and_run_without_reset(vec![0x69, 0x01, 0x00]);
 
     assert_eq!(cpu.register_a, 0x00);
-    assert_eq!(cpu.status.bits(), 0b0011_0011);
+    assert_flags(&cpu, vec![Flags::Zero, Flags::Carry]);
+}
+
+#[cfg(test)]
+mod adc_overflow_flag_tests {
+    use super::*;
+    // reproducing the tests table at:
+    // http://www.righto.com/2012/12/the-6502-overflow-flag-explained.html
+
+    #[test]
+    fn test_0x69_adc_immediate_overflow_1() {
+        let mut cpu = CPU::new();
+        cpu.register_a = 0x50;
+
+        cpu.load_and_run_without_reset(vec![0x69, 0x10, 0x00]);
+        
+        assert_eq!(cpu.register_a, 0x60);
+        assert_no_flags(&cpu)
+    }
+
+    #[test]
+    fn test_0x69_adc_immediate_overflow_2() {
+        let mut cpu = CPU::new();
+        cpu.register_a = 0x50;
+
+        cpu.load_and_run_without_reset(vec![0x69, 0x50, 0x00]);
+
+        assert_eq!(cpu.register_a, 0xA0);
+        assert_flags(&cpu, vec![Flags::Negative, Flags::Overflow]);
+    }
+
+    #[test]
+    fn test_0x69_adc_immediate_overflow_3() {
+        let mut cpu = CPU::new();
+        cpu.register_a = 0x50;
+
+        cpu.load_and_run_without_reset(vec![0x69, 0x90, 0x00]);
+        
+        assert_eq!(cpu.register_a, 0xE0);
+        assert_flags(&cpu, vec![Flags::Negative])
+    }
+
+    #[test]
+    fn test_0x69_adc_immediate_overflow_4() {
+        let mut cpu = CPU::new();
+        cpu.register_a = 0x50;
+
+        cpu.load_and_run_without_reset(vec![0x69, 0xD0, 0x00]);
+        
+        assert_eq!(cpu.register_a, 0x20);
+        assert_flags(&cpu, vec![Flags::Carry]);
+    }
+
+    #[test]
+    fn test_0x69_adc_immediate_overflow_5() {
+        let mut cpu = CPU::new();
+        cpu.register_a = 0xD0;
+
+        cpu.load_and_run_without_reset(vec![0x69, 0x10, 0x00]);
+        
+        assert_eq!(cpu.register_a, 0xE0);
+        assert_flags(&cpu, vec![Flags::Negative]);
+    }
+
+    #[test]
+    fn test_0x69_adc_immediate_overflow_6() {
+        let mut cpu = CPU::new();
+        cpu.register_a = 0xD0;
+
+        cpu.load_and_run_without_reset(vec![0x69, 0x50, 0x00]);
+        
+        assert_eq!(cpu.register_a, 0x20);
+        assert_flags(&cpu, vec![Flags::Carry]);
+    }
+
+    #[test]
+    fn test_0x69_adc_immediate_overflow_7() {
+        let mut cpu = CPU::new();
+        cpu.register_a = 0xD0;
+
+        cpu.load_and_run_without_reset(vec![0x69, 0x90, 0x00]);
+
+        assert_eq!(cpu.register_a, 0x60);
+        assert_flags(&cpu, vec![Flags::Overflow, Flags::Carry]);
+    }
+
+    #[test]
+    fn test_0x69_adc_immediate_overflow_8() {
+        let mut cpu = CPU::new();
+        cpu.register_a = 0xD0;
+
+        cpu.load_and_run_without_reset(vec![0x69, 0xD0, 0x00]);
+        
+        assert_eq!(cpu.register_a, 0xA0);
+        assert_flags(&cpu, vec![Flags::Negative, Flags::Carry]);
+    }
 }
 
 #[test]
-fn test_0x69_adc_immediate_overflow() {
+fn test_0x65_adc_zero_page_adds_correctly() {
     let mut cpu = CPU::new();
-    cpu.register_a = 0xFF;
+    cpu.register_a = 0x01;
+    cpu.memory.write(0x0001, 0x05);
 
-    cpu.load_and_run_without_reset(vec![0x69, 0xFF, 0x00]);
+    cpu.load_and_run_without_reset(vec![0x65, 0x01, 0x00]);
 
-    assert_eq!(cpu.register_a, 0xFE);
-    assert_eq!(cpu.status.bits(), 0b1011_0001);
+    assert_eq!(cpu.register_a, 0x06);
+    assert_no_flags(&cpu);
 }
 
 #[test]
-fn test_0x65_adc_zero_page_add_correctly() {
+fn test_0x75_adc_zero_page_x_adds_correctly() {
     let mut cpu = CPU::new();
-    cpu.register_a = 3;
-    cpu.memory.write(200, 0x05);
+    cpu.register_a = 0x01;
+    cpu.register_x = 0x01;
+    cpu.memory.write(0x02, 0x05);
 
-    cpu.load_and_run_without_reset(vec![0x65, 0x20, 0x00]);
+    cpu.load_and_run_without_reset(vec![0x75, 0x01, 0x00]);
 
-    assert_eq!(cpu.register_a, 8);
-    assert_eq!(cpu.status.bits(), 0b0000_0000);
-    
+    assert_eq!(cpu.register_a, 0x06);
+    assert_no_flags(&cpu);
+}
+
+#[test]
+fn test_0x6d_adc_absolute_adds_correctly() {
+    let mut cpu = CPU::new();
+    cpu.register_a = 0x01;
+    cpu.memory.write(0x1110, 0x05);
+
+    cpu.load_and_run_without_reset(vec![0x6D, 0x10, 0x11, 0x00]);
+
+    assert_eq!(cpu.register_a, 0x06);
+    assert_no_flags(&cpu);
+}
+
+#[test]
+fn test_0x7d_adc_absolute_x_adds_correctly() {
+    let mut cpu = CPU::new();
+    cpu.register_a = 0x01;
+    cpu.register_x = 0x01;
+    cpu.memory.write(0x1111, 0x01);
+
+    cpu.load_and_run_without_reset(vec![0x7D, 0x10, 0x11, 0x00]);
+
+    assert_eq!(cpu.register_a, 0x02);
+    assert_no_flags(&cpu);
+}
+
+#[test]
+fn test_0x79_adc_absolute_y_adds_correctly() {
+    let mut cpu = CPU::new();
+    cpu.register_a = 0x01;
+    cpu.register_y = 0x01;
+    cpu.memory.write(0x1111, 0x01);
+
+    cpu.load_and_run_without_reset(vec![0x79, 0x10, 0x11, 0x00]);
+
+    assert_eq!(cpu.register_a, 0x02);
+    assert_no_flags(&cpu);
+}
+
+#[test]
+fn test_0x61_adc_indirect_x_adds_correctly() {
+    let mut cpu = CPU::new();
+    cpu.register_a = 0x01;
+    cpu.register_x = 0x01;
+    cpu.memory.write(0x0002, 0x11);
+    cpu.memory.write_u16(0x0011, 0x0011);
+
+    cpu.load_and_run_without_reset(vec![0x61, 0x01, 0x00]);
+
+    assert_eq!(cpu.register_a, 0x0012);
+    assert_no_flags(&cpu);
+}
+
+#[test]
+fn test_0x71_adc_indirect_y_adds_correctly() {
+    let mut cpu = CPU::new();
+    cpu.register_a = 0x01;
+    cpu.register_y = 0x01;
+    cpu.memory.write_u16(0x0001, 0x0111);
+    cpu.memory.write_u16(0x0112, 0x02);
+
+    cpu.load_and_run_without_reset(vec![0x71, 0x01, 0x00]);
+
+    assert_eq!(cpu.register_a, 0x03);
+    assert_no_flags(&cpu);
 }

--- a/tests/adc_tests.rs
+++ b/tests/adc_tests.rs
@@ -55,3 +55,16 @@ fn test_0x69_adc_immediate_overflow() {
     assert_eq!(cpu.register_a, 0xFE);
     assert_eq!(cpu.status.bits(), 0b1011_0001);
 }
+
+#[test]
+fn test_0x65_adc_zero_page_add_correctly() {
+    let mut cpu = CPU::new();
+    cpu.register_a = 3;
+    cpu.memory.write(200, 0x05);
+
+    cpu.load_and_run_without_reset(vec![0x65, 0x20, 0x00]);
+
+    assert_eq!(cpu.register_a, 8);
+    assert_eq!(cpu.status.bits(), 0b0000_0000);
+    
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,33 @@
+use std::vec;
+use nes_emulator::cpu::{CPU, Flags};
+
+pub fn assert_no_flags(cpu: &CPU) {
+    assert_flags(cpu, vec![]);
+}
+
+pub fn assert_flags(cpu: &CPU, enabled_flags: Vec<Flags>) {
+    for f in Flags::all() {
+        if (f == Flags::Break) | (f == Flags::Break2) | (f == Flags::Init) {
+            continue;
+        }
+        assert_eq!(
+            cpu.status.contains(f), enabled_flags.contains(&f),
+            "CPU status: {:#010b} | Failing Flag: {} ({:#010b})", cpu.status.bits(), get_flag_name(f), f.bits()
+        )
+    }
+}
+
+fn get_flag_name(f: Flags) -> &'static str {
+    match f {
+        Flags::Init => "Init",
+        Flags::Carry => "Carry",
+        Flags::Zero => "Zero",
+        Flags::InteruptDisable => "Interupt Disable",
+        Flags::Decimal => "Decimal",
+        Flags::Break => "Break",
+        Flags::Break2 => "Break 2",
+        Flags::Overflow => "Overflow",
+        Flags::Negative => "Negative",
+        _ => "Unhandled Flag"
+    }
+}

--- a/tests/cpu_tests.rs
+++ b/tests/cpu_tests.rs
@@ -2,6 +2,9 @@ use std::vec;
 
 use nes_emulator::cpu::{Flags, CPU};
 
+mod common;
+use common::{assert_flags, assert_no_flags};
+
 mod tax {
     use super::*;
 
@@ -14,8 +17,7 @@ mod tax {
 
         assert_eq!(cpu.register_a, 0x01);
         assert_eq!(cpu.register_x, 0x01);
-        assert_eq!(cpu.zero_flag(), false);
-        assert_eq!(cpu.negative_flag(), false);
+        assert_no_flags(&cpu);
     }
 
     #[test]
@@ -27,7 +29,7 @@ mod tax {
 
         assert_eq!(cpu.register_a, 0x00);
         assert_eq!(cpu.register_x, 0x00);
-        assert_eq!(cpu.zero_flag(), true);
+        assert_flags(&cpu, vec![Flags::Zero]);
     }
 
     #[test]
@@ -39,7 +41,7 @@ mod tax {
 
         assert_eq!(cpu.register_a, 0b1000_0000);
         assert_eq!(cpu.register_x, 0b1000_0000);
-        assert_eq!(cpu.negative_flag(), true);
+        assert_flags(&cpu, vec![Flags::Negative]);
     }
 }
 
@@ -55,8 +57,7 @@ mod tay {
 
         assert_eq!(cpu.register_a, 0x01);
         assert_eq!(cpu.register_y, 0x01);
-        assert_eq!(cpu.zero_flag(), false);
-        assert_eq!(cpu.negative_flag(), false);
+        assert_no_flags(&cpu);
     }
 
     #[test]
@@ -68,7 +69,7 @@ mod tay {
 
         assert_eq!(cpu.register_a, 0x00);
         assert_eq!(cpu.register_y, 0x00);
-        assert_eq!(cpu.zero_flag(), true);
+        assert_flags(&cpu, vec![Flags::Zero]);
     }
 
     #[test]
@@ -80,7 +81,7 @@ mod tay {
 
         assert_eq!(cpu.register_a, 0b1000_0000);
         assert_eq!(cpu.register_y, 0b1000_0000);
-        assert_eq!(cpu.negative_flag(), true);
+        assert_flags(&cpu, vec![Flags::Negative]);
     }
 }
 
@@ -95,8 +96,7 @@ mod inx {
         cpu.load_and_run_without_reset(vec![0xE8, 0x00]);
 
         assert_eq!(cpu.register_x, 0x02);
-        assert_eq!(cpu.zero_flag(), false);
-        assert_eq!(cpu.negative_flag(), false);
+        assert_no_flags(&cpu);
     }
 
     #[test]
@@ -106,7 +106,8 @@ mod inx {
         
         cpu.load_and_run_without_reset(vec![0xE8, 0x00]);
 
-        assert_eq!(cpu.register_x, 0)
+        assert_eq!(cpu.register_x, 0);
+        assert_flags(&cpu, vec![Flags::Zero])
     }
 
     #[test]
@@ -117,7 +118,7 @@ mod inx {
         cpu.load_and_run_without_reset(vec![0xE8, 0x00]);
 
         assert_eq!(cpu.register_x, 0x00);
-        assert_eq!(cpu.zero_flag(), true);
+        assert_flags(&cpu, vec![Flags::Zero]);
     }
 
     #[test]
@@ -128,7 +129,7 @@ mod inx {
         cpu.load_and_run_without_reset(vec![0xE8, 0x00]);
 
         assert_eq!(cpu.register_x, 0b1000_0000);
-        assert_eq!(cpu.negative_flag(), true);
+        assert_flags(&cpu, vec![Flags::Negative]);
     }
 }
 

--- a/tests/lda_tests.rs
+++ b/tests/lda_tests.rs
@@ -1,5 +1,8 @@
 use std::vec;
-use nes_emulator::cpu::CPU;
+use nes_emulator::cpu::{CPU, Flags};
+
+mod common;
+use common::{assert_flags, assert_no_flags};
 
 #[test]
 fn test_0xa9_lda_immediate_load_data() {
@@ -8,22 +11,21 @@ fn test_0xa9_lda_immediate_load_data() {
     cpu.load_and_run_without_reset(vec![0xa9, 0x05, 0x00]);
 
     assert_eq!(cpu.register_a, 0x05);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
 fn test_0xa9_lda_immediate_zero_flag() {
     let mut cpu = CPU::new();
     cpu.load_and_run_without_reset(vec![0xa9, 0x00, 0x00]);
-    assert_eq!(cpu.zero_flag(), true);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
 fn test_0xa9_lda_immediate_negative_flag() {
     let mut cpu = CPU::new();
     cpu.load_and_run_without_reset(vec![0xA9, 0b1000_0000, 0x00]);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }
 
 #[test]
@@ -34,8 +36,7 @@ fn test_0xa5_lda_zero_page_load_data() {
     cpu.load_and_run_without_reset(vec![0xA5, 0x05, 0x00]);
 
     assert_eq!(cpu.register_a, 0x01);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
@@ -45,8 +46,7 @@ fn test_0xa5_lda_zero_page_zero_flag() {
     cpu.load_and_run_without_reset(vec![0xA5, 0x05, 0x00]);
 
     assert_eq!(cpu.register_a, 0);
-    assert_eq!(cpu.zero_flag(), true);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
@@ -57,8 +57,7 @@ fn test_0xa5_lda_zero_page_negative_flag() {
     cpu.load_and_run_without_reset(vec![0xA5, 0x05, 0x00]);
 
     assert_eq!(cpu.register_a, 0b1000_0000);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }
 
 #[test]
@@ -70,8 +69,7 @@ fn test_0xb5_lda_zero_page_x_load_data() {
     cpu.load_and_run_without_reset(vec![0xB5, 0x01, 0x00]);
 
     assert_eq!(cpu.register_a, 2);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
@@ -83,8 +81,7 @@ fn test_0xb5_lda_zero_page_x_zero_flag() {
     cpu.load_and_run_without_reset(vec![0xB5, 0x01, 0x00]);
 
     assert_eq!(cpu.register_a, 0);
-    assert_eq!(cpu.zero_flag(), true);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
@@ -96,136 +93,125 @@ fn test_0xb5_lda_zero_page_x_negative_flag() {
     cpu.load_and_run_without_reset(vec![0xB5, 0x01, 0x00]);
 
     assert_eq!(cpu.register_a, 0b1000_0000);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }
 
 #[test]
 fn test_0xad_lda_absolute_load_data() {
     let mut cpu = CPU::new();
-    cpu.memory.write(0x00FF, 0x05);
+    cpu.memory.write(0x1110, 0x05);
 
-    cpu.load_and_run_without_reset(vec![0xAD, 0x00FF, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xAD, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_a, 0x05);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
 fn test_0xad_lda_absolute_zero_flag() {
     let mut cpu = CPU::new();
-    cpu.memory.write(0x00FF, 0);
+    cpu.memory.write(0x1110, 0);
 
-    cpu.load_and_run_without_reset(vec![0xAD, 0x00FF, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xAD, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_a, 0);
-    assert_eq!(cpu.zero_flag(), true);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
 fn test_0xad_lda_absolute_negative_flag() {
     let mut cpu = CPU::new();
-    cpu.memory.write(0x00FF, 0b1000_0000);
+    cpu.memory.write(0x1110, 0b1000_0000);
 
-    cpu.load_and_run_without_reset(vec![0xAD, 0x00FF, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xAD, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_a, 0b1000_0000);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }
 
 #[test]
 fn test_0xbd_lda_absolute_x_load_data() {
     let mut cpu = CPU::new();
     cpu.register_x = 1;
-    cpu.memory.write(0x00FF, 0x05);
+    cpu.memory.write(0x1111, 0x05);
 
-    cpu.load_and_run_without_reset(vec![0xBD, 0x00FE, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xBD, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_a, 0x05);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
 fn test_0xbd_lda_absolute_x_zero_flag() {
     let mut cpu = CPU::new();
     cpu.register_x = 1;
-    cpu.memory.write(0x00FF, 0);
+    cpu.memory.write(0x1111, 0);
 
-    cpu.load_and_run_without_reset(vec![0xBD, 0x00FE, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xBD, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_a, 0);
-    assert_eq!(cpu.zero_flag(), true);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
 fn test_0xbd_lda_absolute_x_negative_flag() {
     let mut cpu = CPU::new();
     cpu.register_x = 1;
-    cpu.memory.write(0x00FF, 0b1000_0000);
+    cpu.memory.write(0x1111, 0b1000_0000);
 
-    cpu.load_and_run_without_reset(vec![0xBD, 0x00FE, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xBD, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_a, 0b1000_0000);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }
 
 #[test]
 fn test_0xb9_lda_absolute_y_load_data() {
     let mut cpu = CPU::new();
     cpu.register_y = 1;
-    cpu.memory.write(0x00FF, 0x05);
+    cpu.memory.write(0x1111, 0x05);
 
-    cpu.load_and_run_without_reset(vec![0xB9, 0x00FE, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xB9, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_a, 0x05);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
 fn test_0xb9_lda_absolute_y_zero_flag() {
     let mut cpu = CPU::new();
     cpu.register_y = 1;
-    cpu.memory.write(0x00FF, 0);
+    cpu.memory.write(0x1111, 0);
 
-    cpu.load_and_run_without_reset(vec![0xB9, 0x00FE, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xB9, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_a, 0);
-    assert_eq!(cpu.zero_flag(), true);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
 fn test_0xb9_lda_absolute_y_negative_flag() {
     let mut cpu = CPU::new();
     cpu.register_y = 1;
-    cpu.memory.write(0x00FF, 0b1000_0000);
+    cpu.memory.write(0x1111, 0b1000_0000);
 
-    cpu.load_and_run_without_reset(vec![0xB9, 0x00FE, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xB9, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_a, 0b1000_0000);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }
 
 #[test]
 fn test_0xa1_lda_indirect_x_load_data() {
     let mut cpu = CPU::new();
-    cpu.register_x = 1;
+    cpu.register_x = 0x01;
     cpu.memory.write_u16(0x02, 0x1000);
     cpu.memory.write(0x1000, 0x05);
 
     cpu.load_and_run_without_reset(vec![0xA1, 0x01, 0x00]);
 
     assert_eq!(cpu.register_a, 0x05);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
@@ -238,8 +224,7 @@ fn test_0xa1_lda_indirect_x_zero_flag() {
     cpu.load_and_run_without_reset(vec![0xA1, 0x01, 0x00]);
 
     assert_eq!(cpu.register_a, 0);
-    assert_eq!(cpu.zero_flag(), true);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
@@ -252,6 +237,5 @@ fn test_0xa1_lda_indirect_x_negative_flag() {
     cpu.load_and_run_without_reset(vec![0xA1, 0x01, 0x00]);
 
     assert_eq!(cpu.register_a, 0b1000_0000);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }

--- a/tests/ldx_tests.rs
+++ b/tests/ldx_tests.rs
@@ -1,5 +1,8 @@
 use std::vec;
-use nes_emulator::cpu::CPU;
+use nes_emulator::cpu::{CPU, Flags};
+
+mod common;
+use common::{assert_flags, assert_no_flags};
 
 #[test]
 fn test_0xa2_ldx_immediate_load_data() {
@@ -8,22 +11,21 @@ fn test_0xa2_ldx_immediate_load_data() {
     cpu.load_and_run_without_reset(vec![0xa2, 0x05, 0x00]);
 
     assert_eq!(cpu.register_x, 0x05);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
 fn test_0xa2_ldx_immediate_zero_flag() {
     let mut cpu = CPU::new();
     cpu.load_and_run_without_reset(vec![0xa2, 0x00, 0x00]);
-    assert_eq!(cpu.zero_flag(), true);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
 fn test_0xa2_ldx_immediate_negative_flag() {
     let mut cpu = CPU::new();
     cpu.load_and_run_without_reset(vec![0xa2, 0b1000_0000, 0x00]);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }
 
 #[test]
@@ -34,8 +36,7 @@ fn test_0xa6_ldx_zero_page_load_data() {
     cpu.load_and_run_without_reset(vec![0xa6, 0x05, 0x00]);
 
     assert_eq!(cpu.register_x, 0x01);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
@@ -45,8 +46,7 @@ fn test_0xa6_ldx_zero_page_zero_flag() {
     cpu.load_and_run_without_reset(vec![0xa6, 0x05, 0x00]);
 
     assert_eq!(cpu.register_x, 0);
-    assert_eq!(cpu.zero_flag(), true);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
@@ -57,8 +57,7 @@ fn test_0xa6_ldx_zero_page_negative_flag() {
     cpu.load_and_run_without_reset(vec![0xa6, 0x05, 0x00]);
 
     assert_eq!(cpu.register_x, 0b1000_0000);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }
 
 #[test]
@@ -70,8 +69,7 @@ fn test_0xb6_ldx_zero_page_y_load_data() {
     cpu.load_and_run_without_reset(vec![0xB6, 0x01, 0x00]);
 
     assert_eq!(cpu.register_x, 2);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
@@ -83,8 +81,7 @@ fn test_0xb6_ldx_zero_page_y_zero_flag() {
     cpu.load_and_run_without_reset(vec![0xB6, 0x01, 0x00]);
 
     assert_eq!(cpu.register_x, 0);
-    assert_eq!(cpu.zero_flag(), true);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
@@ -96,81 +93,74 @@ fn test_0xb6_ldx_zero_page_y_negative_flag() {
     cpu.load_and_run_without_reset(vec![0xB6, 0x01, 0x00]);
 
     assert_eq!(cpu.register_x, 0b1000_0000);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }
 
 #[test]
 fn test_0xae_ldx_absolute_load_data() {
     let mut cpu = CPU::new();
-    cpu.memory.write(0x00FF, 0x05);
+    cpu.memory.write(0x1110, 0x05);
 
-    cpu.load_and_run_without_reset(vec![0xae, 0x00FF, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xae, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_x, 0x05);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
 fn test_0xae_ldx_absolute_zero_flag() {
     let mut cpu = CPU::new();
-    cpu.memory.write(0x00FF, 0);
+    cpu.memory.write(0x1110, 0);
 
-    cpu.load_and_run_without_reset(vec![0xae, 0x00FF, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xae, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_x, 0x00);
-    assert_eq!(cpu.zero_flag(), true);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
 fn test_0xae_ldx_absolute_negative_flag() {
     let mut cpu = CPU::new();
-    cpu.memory.write(0x00FF, 0b1000_0000);
+    cpu.memory.write(0x1110, 0b1000_0000);
 
-    cpu.load_and_run_without_reset(vec![0xae, 0x00FF, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xae, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_x, 0b1000_0000);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }
 
 #[test]
 fn test_0xbe_ldx_absolute_y_load_data() {
     let mut cpu = CPU::new();
     cpu.register_y = 1;
-    cpu.memory.write(0x00FF, 0x05);
+    cpu.memory.write(0x1111, 0x05);
 
-    cpu.load_and_run_without_reset(vec![0xbe, 0x00FE, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xbe, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_x, 0x05);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
 fn test_0xbe_ldx_absolute_y_zero_flag() {
     let mut cpu = CPU::new();
     cpu.register_y = 1;
-    cpu.memory.write(0x00FF, 0);
+    cpu.memory.write(0x1111, 0);
 
-    cpu.load_and_run_without_reset(vec![0xbe, 0x00FE, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xbe, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_x, 0);
-    assert_eq!(cpu.zero_flag(), true);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
 fn test_0xbe_ldx_absolute_y_negative_flag() {
     let mut cpu = CPU::new();
     cpu.register_y = 1;
-    cpu.memory.write(0x00FF, 0b1000_0000);
+    cpu.memory.write(0x1111, 0b1000_0000);
 
-    cpu.load_and_run_without_reset(vec![0xbe, 0x00FE, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xbe, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_x, 0b1000_0000);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }

--- a/tests/ldy_tests.rs
+++ b/tests/ldy_tests.rs
@@ -1,5 +1,8 @@
 use std::vec;
-use nes_emulator::cpu::CPU;
+use nes_emulator::cpu::{CPU, Flags};
+
+mod common;
+use common::{assert_flags, assert_no_flags};
 
 #[test]
 fn test_0xa0_ldy_immediate_load_data() {
@@ -8,22 +11,21 @@ fn test_0xa0_ldy_immediate_load_data() {
     cpu.load_and_run_without_reset(vec![0xa0, 0x05, 0x00]);
 
     assert_eq!(cpu.register_y, 0x05);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
 fn test_0xa0_ldy_immediate_zero_flag() {
     let mut cpu = CPU::new();
     cpu.load_and_run_without_reset(vec![0xa0, 0x00, 0x00]);
-    assert_eq!(cpu.zero_flag(), true);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
 fn test_0xa0_ldy_immediate_negative_flag() {
     let mut cpu = CPU::new();
     cpu.load_and_run_without_reset(vec![0xa0, 0b1000_0000, 0x00]);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }
 
 #[test]
@@ -34,8 +36,7 @@ fn test_0xa4_ldy_zero_page_load_data() {
     cpu.load_and_run_without_reset(vec![0xa4, 0x05, 0x00]);
 
     assert_eq!(cpu.register_y, 0x01);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
@@ -45,8 +46,7 @@ fn test_0xa4_ldy_zero_page_zero_flag() {
     cpu.load_and_run_without_reset(vec![0xa4, 0x05, 0x00]);
 
     assert_eq!(cpu.register_y, 0);
-    assert_eq!(cpu.zero_flag(), true);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
@@ -57,8 +57,7 @@ fn test_0xa4_ldy_zero_page_negative_flag() {
     cpu.load_and_run_without_reset(vec![0xa4, 0x05, 0x00]);
 
     assert_eq!(cpu.register_y, 0b1000_0000);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }
 
 #[test]
@@ -70,8 +69,7 @@ fn test_0xb4_ldy_zero_page_x_load_data() {
     cpu.load_and_run_without_reset(vec![0xb4, 0x01, 0x00]);
 
     assert_eq!(cpu.register_y, 2);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
@@ -83,8 +81,7 @@ fn test_0xb4_ldy_zero_page_x_zero_flag() {
     cpu.load_and_run_without_reset(vec![0xb4, 0x01, 0x00]);
 
     assert_eq!(cpu.register_y, 0);
-    assert_eq!(cpu.zero_flag(), true);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
@@ -96,81 +93,74 @@ fn test_0xb4_ldy_zero_page_x_negative_flag() {
     cpu.load_and_run_without_reset(vec![0xb4, 0x01, 0x00]);
 
     assert_eq!(cpu.register_y, 0b1000_0000);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }
 
 #[test]
 fn test_0xac_ldy_absolute_load_data() {
     let mut cpu = CPU::new();
-    cpu.memory.write(0x00FF, 0x05);
+    cpu.memory.write(0x1110, 0x05);
 
-    cpu.load_and_run_without_reset(vec![0xac, 0x00FF, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xac, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_y, 0x05);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
 fn test_0xac_ldy_absolute_zero_flag() {
     let mut cpu = CPU::new();
-    cpu.memory.write(0x00FF, 0);
+    cpu.memory.write(0x1110, 0);
 
-    cpu.load_and_run_without_reset(vec![0xac, 0x00FF, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xac, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_y, 0);
-    assert_eq!(cpu.zero_flag(), true);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
 fn test_0xac_ldy_absolute_negative_flag() {
     let mut cpu = CPU::new();
-    cpu.memory.write(0x00FF, 0b1000_0000);
+    cpu.memory.write(0x1110, 0b1000_0000);
 
-    cpu.load_and_run_without_reset(vec![0xac, 0x00FF, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xac, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_y, 0b1000_0000);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }
 
 #[test]
 fn test_0xbc_ldy_absolute_x_load_data() {
     let mut cpu = CPU::new();
     cpu.register_x = 1;
-    cpu.memory.write(0x00FF, 0x05);
+    cpu.memory.write(0x1111, 0x05);
 
-    cpu.load_and_run_without_reset(vec![0xbc, 0x00FE, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xbc, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_y, 0x05);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_no_flags(&cpu);
 }
 
 #[test]
 fn test_0xbc_ldy_absolute_x_zero_flag() {
     let mut cpu = CPU::new();
     cpu.register_x = 1;
-    cpu.memory.write(0x00FF, 0);
+    cpu.memory.write(0x1111, 0);
 
-    cpu.load_and_run_without_reset(vec![0xbc, 0x00FE, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xbc, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_y, 0);
-    assert_eq!(cpu.zero_flag(), true);
-    assert_eq!(cpu.negative_flag(), false);
+    assert_flags(&cpu, vec![Flags::Zero]);
 }
 
 #[test]
 fn test_0xbc_ldy_absolute_x_negative_flag() {
     let mut cpu = CPU::new();
     cpu.register_x = 1;
-    cpu.memory.write(0x00FF, 0b1000_0000);
+    cpu.memory.write(0x1111, 0b1000_0000);
 
-    cpu.load_and_run_without_reset(vec![0xbc, 0x00FE, 0x00]);
+    cpu.load_and_run_without_reset(vec![0xbc, 0x10, 0x11, 0x00]);
 
     assert_eq!(cpu.register_y, 0b1000_0000);
-    assert_eq!(cpu.zero_flag(), false);
-    assert_eq!(cpu.negative_flag(), true);
+    assert_flags(&cpu, vec![Flags::Negative]);
 }


### PR DESCRIPTION
# 📖 Description
This PR includes:

- The implementation of the `ADC` operator
- A rework of the `IndirectX` and `IndirectY` addressing mode as it was implemented incorrectly
- Addition of test functions `assert_no_flags/1` and `assert_flags/2` and refactor of tests to use them